### PR TITLE
Cleanup build system

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -59,13 +59,10 @@ all-local: nq
 	@echo "SUCCESS!"
 
 clean-local:
-	(cd examples; make clean)
+	rm -f examples/G?.tst examples/G?.old *~
 	(cd doc && rm -f *.aux *.bbl *.blg *.brf *.idx *.ilg *.ind *.log *.out *.pnr *.tex *.toc)
 	(cd doc && rm -f test/nqman.tst test/diffs)
-
-distclean-local:
-	(cd examples; make distclean)
-	rm -rf bin/*
+	rm -rf $(top_srcdir)/$(BINARCHDIR)
 
 doc:
 	(echo 'Read("makedoc.g");' | $(GAPROOT)/bin/gap.sh -A -q)

--- a/configure.ac
+++ b/configure.ac
@@ -11,15 +11,9 @@ AC_CONFIG_SRCDIR([src/nq.c])
 AC_CONFIG_HEADER(src/config.h:src/config.hin)
 AC_CONFIG_AUX_DIR([cnf])
 AC_CONFIG_MACRO_DIR([m4])
-AM_INIT_AUTOMAKE([1.11 -Wall foreign subdir-objects])
+AM_INIT_AUTOMAKE([1.11 -Wall foreign subdir-objects no-dist])
 AM_SILENT_RULES([yes])
 AM_MAINTAINER_MODE
-
-dnl
-dnl Setup libtool (for interfacing with GAP kernel extension)
-dnl
-LT_PREREQ([2.4.2])
-LT_INIT
 
 dnl ##
 dnl ## C is the language
@@ -34,11 +28,6 @@ AC_PROG_CC
 AC_PROG_MAKE_SET
 AC_PROG_MKDIR_P
 AC_PROG_SED
-
-dnl ##
-dnl ## Checks for system header files.
-dnl ##
-AC_CHECK_HEADERS([stdlib.h string.h sys/time.h])
 
 
 dnl ##
@@ -57,7 +46,7 @@ if test "${with_gaproot+set}" != set; then :
   fi
 fi
 
-AC_FIND_GAP
+FIND_GAP
 
 
 dnl ##
@@ -108,8 +97,6 @@ AC_TYPE_LONG_LONG_INT
 dnl ##
 dnl ## Checks for library functions.
 dnl ##
-AC_FUNC_MALLOC
-AC_FUNC_REALLOC
 AC_CHECK_FUNCS([sbrk getrusage])
 
 dnl ##

--- a/m4/find_gap.m4
+++ b/m4/find_gap.m4
@@ -3,7 +3,7 @@
 # Can be configured using --with-gaproot=...
 #######################################################################
 
-AC_DEFUN([AC_FIND_GAP],
+AC_DEFUN([FIND_GAP],
 [
   AC_LANG_PUSH([C])
 
@@ -18,10 +18,9 @@ AC_DEFUN([AC_FIND_GAP],
   AC_MSG_CHECKING([for GAP root directory])
   GAPROOT="../.."
 
-  #Allow the user to specify the location of GAP
-  #
+  # Allow the user to specify the location of GAP
   AC_ARG_WITH(gaproot,
-    [AC_HELP_STRING([--with-gaproot=<path>], [specify root of GAP installation])],
+    [AS_HELP_STRING([--with-gaproot=<path>], [specify root of GAP installation])],
     [GAPROOT="$withval"])
 
   # Convert the path to absolute
@@ -72,65 +71,20 @@ AC_DEFUN([AC_FIND_GAP],
     AC_MSG_ERROR([Unable to find plausible GAParch information.])
   fi
 
-
-  AC_MSG_CHECKING([for GAP >= 4.9])
-  # test if this GAP >= 4.9
-  if test "x$GAP_CPPFLAGS" != x; then
-    AC_MSG_RESULT([yes])
-  else
-    AC_MSG_RESULT([no])
-    #####################################
-    # Now check for the GAP header files
-
-    bad=0
-    AC_MSG_CHECKING([for GAP include files])
-    if test -r $GAPROOT/src/compiled.h; then
-      AC_MSG_RESULT([$GAPROOT/src/compiled.h])
-    else
-      AC_MSG_RESULT([Not found])
-      bad=1
-    fi
-    AC_MSG_CHECKING([for GAP config.h])
-    if test -r $GAPROOT/bin/$GAPARCH/config.h; then
-      AC_MSG_RESULT([$GAPROOT/bin/$GAPARCH/config.h])
-    else
-      AC_MSG_RESULT([Not found])
-      bad=1
-    fi
-
-    if test "x$bad" = "x1"; then
-      echo ""
-      echo "********************************************************************"
-      echo "  ERROR"
-      echo ""
-      echo "  Failed to find the GAP source header files in src/ and"
-      echo "  GAP's config.h in the architecture dependend directory"
-      echo ""
-      echo "  The kernel build process expects to find the normal GAP "
-      echo "  root directory structure as it is after building GAP itself, and"
-      echo "  in particular the files"
-      echo "      <gaproot>/sysinfo.gap"
-      echo "      <gaproot>/src/<includes>"
-      echo "  and <gaproot>/bin/<architecture>/bin/config.h."
-      echo "  Please make sure that your GAP root directory structure"
-      echo "  conforms to this layout, or give the correct GAP root using"
-      echo "  --with-gaproot=<path>"
-      echo "********************************************************************"
-      echo ""
-      AC_MSG_ERROR([Unable to find GAP include files in /src subdirectory])
-    fi
-
-    ARCHPATH=$GAPROOT/bin/$GAPARCH
-    GAP_CPPFLAGS="-I$GAPROOT -iquote $GAPROOT/src -I$ARCHPATH"
-
-    AC_MSG_CHECKING([for GAP's gmp.h location])
-    if test -r "$ARCHPATH/extern/gmp/include/gmp.h"; then
-      GAP_CPPFLAGS="$GAP_CPPFLAGS -I$ARCHPATH/extern/gmp/include"
-      AC_MSG_RESULT([$ARCHPATH/extern/gmp/include/gmp.h])
-    else
-      AC_MSG_RESULT([not found, GAP was compiled without its own GMP])
-    fi
+  # require GAP >= 4.9
+  if test "x$GAP_CPPFLAGS" = x; then
+    echo ""
+    echo "********************************************************************"
+    echo "  ERROR"
+    echo ""
+    echo "  This version of GAP is too old and not supported by this package."
+    echo "********************************************************************"
+    echo ""
+    AC_MSG_ERROR([No GAP_CPPFLAGS is given])
   fi
+
+  # compatibility with GAP 4.9 (not needed in GAP >= 4.10)
+  GAP_CPPFLAGS="$GAP_CPPFLAGS -I${GAP_LIB_DIR}/src"
 
   AC_SUBST(GAPARCH)
   AC_SUBST(GAPROOT)


### PR DESCRIPTION
- no need for using libtool
- disable unusued automake dist mode
- remove a distclean-local rule (we don't support distclean either)
- switch from AC_FIND_GAP to FIND_GAP
- remove some unnecessary configure checks

Resolves #10
Resolves #7