### PR TITLE
buildsys tweaks

### DIFF
--- a/.release
+++ b/.release
@@ -1,4 +1,5 @@
 #!/bin/sh
 # This file is executed by the `release` script from
 # https://github.com/gap-system/ReleaseTools
-rm -rf .travis.yml .codecov.yml
+rm -rf .codecov.yml
+perl -pi -e 's/AM_MAINTAINER_MODE\(\[enable\]\)/AM_MAINTAINER_MODE\(\[disable\]\)/' configure.ac

--- a/configure.ac
+++ b/configure.ac
@@ -39,19 +39,6 @@ AC_PROG_SED
 dnl ##
 dnl ## Locate the GAP root dir
 dnl ##
-
-# HACK: We used to support --with-gap-root, but this got renamed to
-# --with-gaproot for compatibility with other packages (io, orb, cvec,
-# ...). But existing build scripts may use the old name, so we translate
-# it to the new name here.
-# Note: configure warns if --with-gap-root is used, calling
-# it an unrecognized option.
-if test "${with_gaproot+set}" != set; then :
-  if test "${with_gap_root+set}" = set; then :
-    with_gaproot=$with_gap_root
-  fi
-fi
-
 FIND_GAP
 
 dnl ##

--- a/configure.ac
+++ b/configure.ac
@@ -13,7 +13,13 @@ AC_CONFIG_AUX_DIR([cnf])
 AC_CONFIG_MACRO_DIR([m4])
 AM_INIT_AUTOMAKE([1.11 -Wall foreign subdir-objects no-dist])
 AM_SILENT_RULES([yes])
-AM_MAINTAINER_MODE
+
+dnl For developer builds, maintainer mode is enabled by default. But for
+dnl releases, the `.release` script changes this to "disabled by default".
+dnl This avoids troubles during packaging, in particular when the GAP team
+dnl repackages the source archive. Users can re-enable it by passing
+dnl `--enable-maintainer-mode` to configure.
+AM_MAINTAINER_MODE([enable])
 
 dnl ##
 dnl ## C is the language


### PR DESCRIPTION
- buildsys: enable maintainer mode only in dev builds
- buildsys: remove support for --with-gap-root (use --with-gaproot instead)
