### PR TITLE
configure: add back `--with-gmp`

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,9 @@
 This file describes changes in the GAP package 'nq'.
 ===========================================================================
 
+X.Y.Z (YYYY-MM-DD)
+  - Restore `--with-gmp` configure option
+
 2.5.7 (2022-03-16)
   - Don't abort certain computations just because an "unknown"
     global option is on the GAP "Options Stack"

--- a/Makefile.am
+++ b/Makefile.am
@@ -26,9 +26,9 @@ nq_SOURCES = \
     src/trmetab.c \
     src/word.c
 
-nq_LDFLAGS = $(GAP_LDFLAGS)
-nq_LDADD = $(GAP_LIBS)
-nq_CPPFLAGS = $(GAP_CPPFLAGS)
+nq_LDFLAGS = $(GMP_LDFLAGS)
+nq_LDADD = $(GMP_LIBS)
+nq_CPPFLAGS = $(GMP_CPPFLAGS)
 
 #CFLAGS += -O3 -Wuninitialized
 

--- a/configure.ac
+++ b/configure.ac
@@ -42,6 +42,78 @@ dnl ##
 FIND_GAP
 
 dnl ##
+dnl ## Check for GMP
+dnl ##
+
+AC_ARG_WITH([gmp],
+  [AS_HELP_STRING([--with-gmp@<:@=PREFIX@:>@],
+    [prefix of GMP installation. e.g. /usr/local])],
+    [],[with_gmp=yes])
+
+GMP_CPPFLAGS=""
+GMP_LDFLAGS=""
+GMP_LIBS="-lgmp"
+
+if test "x$with_gmp" = "xno" ; then
+	AC_MSG_ERROR([GMP is required and cannot be disabled])
+elif test "x$with_gmp" = "xyes" ; then
+    # If a gaproot was specified, try to find GMP in there; otherwise, fall
+    # back to whatever GMP may be found via user specified C/CPP/LDFLAGS
+    if test "${with_gaproot+set}" = set; then
+        echo "with_gaproot = $with_gaproot"
+        if test -f ${with_gaproot}/extern/install/gmp/include/gmp.h && test -d ${with_gaproot}/extern/install/gmp/lib ; then
+            echo "adjusting stuff based on gaproot"
+            GMP_CPPFLAGS="-I${with_gaproot}/extern/install/gmp/include"
+            GMP_LDFLAGS="-L${with_gaproot}/extern/install/gmp/lib"
+        fi
+    fi
+else
+	if test -d ${with_gmp}/include && test -d ${with_gmp}/lib ; then
+		GMP_CPPFLAGS="-I${with_gmp}/include"
+        GMP_LDFLAGS="-L${with_gmp}/lib"
+	else
+		AC_MSG_ERROR([Could not locate libgmp.a in the specified location])
+	fi
+fi;
+
+save_CPPFLAGS="$CPPFLAGS"
+save_LDFLAGS="$LDFLAGS"
+save_LIBS="$LIBS"
+
+CPPFLAGS="$CPPFLAGS $GMP_CPPFLAGS"
+LDFLAGS="$LDFLAGS $GMP_LDFLAGS"
+LIBS="$LIBS $GMP_LIBS"
+
+AC_CHECK_HEADER( [gmp.h],
+    [
+    # TODO: Disable linker check for now: It causes problems on Linux, because
+    # libgmp.a is in the linker command line before the test C file. On the long
+    # run, this should be re-enabled, though perhaps in a different form.
+    AC_MSG_CHECKING([whether linking against GMP works])
+    AC_LINK_IFELSE(
+        [AC_LANG_PROGRAM([[#include <gmp.h>]], [[__gmpz_init(0);]])],
+        [have_gmp=yes],
+        []
+        )
+    AC_MSG_RESULT([$have_gmp])
+    ],
+    []
+    )
+
+# restore FLAGS
+CPPFLAGS="$save_CPPFLAGS"
+LDFLAGS="$save_LDFLAGS"
+LIBS="$save_LIBS"
+
+if test "x$have_gmp" != xyes; then
+    AC_MSG_ERROR([Could not locate GMP, the GNU multiprecision library])
+fi
+
+AC_SUBST(GMP_CPPFLAGS)
+AC_SUBST(GMP_LDFLAGS)
+AC_SUBST(GMP_LIBS)
+
+dnl ##
 dnl ## Checks for typedefs, structures, and compiler characteristics.
 dnl ##
 AC_TYPE_LONG_LONG_INT

--- a/m4/find_gap.m4
+++ b/m4/find_gap.m4
@@ -83,9 +83,6 @@ AC_DEFUN([FIND_GAP],
     AC_MSG_ERROR([No GAP_CPPFLAGS is given])
   fi
 
-  # compatibility with GAP 4.9 (not needed in GAP >= 4.10)
-  GAP_CPPFLAGS="$GAP_CPPFLAGS -I${GAP_LIB_DIR}/src"
-
   AC_SUBST(GAPARCH)
   AC_SUBST(GAPROOT)
   AC_SUBST(GAP_CPPFLAGS)


### PR DESCRIPTION
This is what we really need; and while trying to figure out which GMP GAP used may look "cool", it always was a gross hack -- and also not strictly needed, in the sense that GAP and nq do not need to be linked against the same version of GMP, as is necessary for kernel extensions using GMP.

That main drawback here is inconvenience for those users who build GAP with its bundled GMP and who know have to figure out how to point nq at it. (IMHO they'd better off learning how to install GMP system wide anyway ...)

Resolves #20
Resolves #21