### PR TITLE
Handle windows executables ending in .exe

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -52,9 +52,9 @@ nq_CFLAGS = \
 # -Werror
 
 
-all-local: nq
+all-local: nq$(EXEEXT)
 	$(mkdir_p) $(top_srcdir)/$(BINARCHDIR)
-	cp nq $(abs_top_srcdir)/$(BINARCHDIR)
+	cp nq$(EXEEXT) $(abs_top_srcdir)/$(BINARCHDIR)
 	@echo "SUCCESS!"
 
 clean-local:


### PR DESCRIPTION
This PR makes nq build on cygwin (the build was mostly fine, we just need to use EXEEXT, which is empty on linux (and I assume mac), but is `.exe` on windows/cygwin