### PR TITLE
mh/misc

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -67,4 +67,10 @@ clean-local:
 doc:
 	(echo 'Read("makedoc.g");' | $(GAPROOT)/bin/gap.sh -A -q)
 
-.PHONY: doc
+check:
+	(cd examples; make)
+
+test:
+	(cd examples; make)
+
+.PHONY: check doc test

--- a/src/glimt.c
+++ b/src/glimt.c
@@ -86,33 +86,15 @@ FILE    *RawMatFile = NULL;
 
 
 static large ltom(expo n) {
-	char    x[64];
 	MP_INT  *l = (MP_INT*)Allocate(sizeof(MP_INT));
-	int     sign = 1;
-
-	if (n < (expo)0) { sign = -1; n = -n; }
 
 	/*
 	** There does not seem to be a function that converts from long long
 	** to a large integer.  So we have to do it a bit more complicated.
 	*/
-#ifdef HAVE_LONG_LONG_INT
-	sprintf(x, "%llx", n);
-#else
-	sprintf(x, "%lx", n);
-#endif
-
-	mpz_init(l);
-	mpz_set_str(l, x, 16);
-
-	if (0) {
-		printf(EXP_FORMAT" ", n);
-		mpz_out_str(stdout, 10, l);
-		printf("\n");
-	}
-
-
-	if (sign == -1) NEGATE(l);
+	mpz_init_set_si(l, (int)(n >> 32));
+	mpz_mul_2exp(l, l, 32 );
+	mpz_add_ui(l, l, (unsigned int)n);
 
 	return l;
 }

--- a/src/glimt.c
+++ b/src/glimt.c
@@ -22,27 +22,13 @@
 typedef MP_INT  *large;
 typedef large   *lvec;
 
-/*
-**    The name of the structure components in MINT have changed.  I
-**    knew from the start that I shouldn't have done that.
-*/
-#if __GNU_MP__+0 >= 2
-#    define NOTZERO(l) ((l)->_mp_size != 0)
-#    define ISZERO(l)  ((l)->_mp_size == 0)
-#    define ISNEG(l)   ((l)->_mp_size < 0)
-#    define NEGATE(l)  ((l)->_mp_size = -(l)->_mp_size)
-#    define SIGN(l)    (expo)(sgn((l)->_mp_size))
-#    define SIZE(l)    ((l)->_mp_size)
-#    define LIMB(l,i)  (expo)((l)->_mp_d[i])
-#else
-#    define NOTZERO(l) ((l)->size != 0)
-#    define ISZERO(l)  ((l)->size == 0)
-#    define ISNEG(l)   ((l)->size < 0)
-#    define NEGATE(l)  ((l)->size = -(l)->size)
-#    define SIGN(l)    (expo)(sgn((l)->size))
-#    define SIZE(l)    ((l)->size)
-#    define LIMB(l,i)  (expo)((l)->d[i])
-#endif
+#define NOTZERO(l) ((l)->_mp_size != 0)
+#define ISZERO(l)  ((l)->_mp_size == 0)
+#define ISNEG(l)   ((l)->_mp_size < 0)
+#define NEGATE(l)  ((l)->_mp_size = -(l)->_mp_size)
+#define SIGN(l)    (expo)(sgn((l)->_mp_size))
+#define SIZE(l)    ((l)->_mp_size)
+#define LIMB(l,i)  (expo)((l)->_mp_d[i])
 
 
 /*


### PR DESCRIPTION
- Simplify ltom() conversion from expo to mpz
- Stop pretending GMP 1.x is supported
- Restore 'make test', add 'make check' alias (resolves #9)
